### PR TITLE
(fix) Add hooks to update point if zipcode changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "node": true
   },
   "rules": {
+    "consistent-return": ["off"],
     "func-names": ["error", "never"],
     "no-console": "off",
     "no-underscore-dangle": "off",

--- a/src/models/chef.js
+++ b/src/models/chef.js
@@ -89,5 +89,17 @@ module.exports = function(sequelize, DataTypes) {
       });
   });
 
+  Chef.beforeUpdate(function(chef, options) {
+    if (chef.zipcode !== chef._previousDataValues.zipcode) {
+      return sequelize.models.Zipcode.findById(chef.zipcode)
+        .then(function(zip) {
+          chef.point = {
+            type: 'POINT',
+            coordinates: [zip.lat, zip.lng]
+          };
+        });
+    }
+  });
+
   return Chef;
 };

--- a/src/models/meal.js
+++ b/src/models/meal.js
@@ -84,5 +84,17 @@ module.exports = function(sequelize, DataTypes) {
       });
   });
 
+  Meal.beforeUpdate(function(meal, options) {
+    if (meal.zipcode !== meal._previousDataValues.zipcode) {
+      return sequelize.models.Zipcode.findById(meal.zipcode)
+        .then(function(zip) {
+          meal.point = {
+            type: 'POINT',
+            coordinates: [zip.lat, zip.lng]
+          };
+        });
+    }
+  });
+
   return Meal;
 };

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -76,5 +76,17 @@ module.exports = function(sequelize, DataTypes) {
       });
   });
 
+  User.beforeUpdate(function(user, options) {
+    if (user.zipcode !== user._previousDataValues.zipcode) {
+      return sequelize.models.Zipcode.findById(user.zipcode)
+        .then(function(zip) {
+          user.point = {
+            type: 'POINT',
+            coordinates: [zip.lat, zip.lng]
+          };
+        });
+    }
+  });
+
   return User;
 };


### PR DESCRIPTION
If the zipcode of a meal/chef/user changes, the lat/lng point associated with it should also be updated with the new zipcode.