### PR TITLE
(fix) Move routes so they are not matched prematurely

### DIFF
--- a/src/routes/chefs-routes.js
+++ b/src/routes/chefs-routes.js
@@ -69,15 +69,6 @@ router.get('/', function(req, res) {
     });
 });
 
-// GET /api/chefs/:id
-// Get a specific chef
-router.get('/:id', function(req, res) {
-  return chefCtrl.getChef(req.params.id)
-    .then(function(chef) {
-      return res.json(chef);
-    });
-});
-
 // POST /api/chefs/login
 // Login for chefs
 router.post('/login', function(req, res, next) {
@@ -294,6 +285,15 @@ router.delete('/requests/:id', isChef, function(req, res) {
         });
       });
   });
+});
+
+// GET /api/chefs/:id
+// Get a specific chef
+router.get('/:id', function(req, res) {
+  return chefCtrl.getChef(req.params.id)
+    .then(function(chef) {
+      return res.json(chef);
+    });
 });
 
 module.exports = router;

--- a/src/routes/users-routes.js
+++ b/src/routes/users-routes.js
@@ -94,15 +94,6 @@ router.get('/', function(req, res) {
     });
 });
 
-// GET /api/users/:id
-// Get a specific user
-router.get('/:id', function(req, res) {
-  return userCtrl.getUser(req.params.id)
-    .then(function(user) {
-      return res.json(user);
-    });
-});
-
 // /api/users/login
 // Login for users
 router.post('/login', function(req, res, next) {
@@ -175,33 +166,33 @@ router.post('/signup', function(req, res, next) {
 // Get all meals the user has purchased
 router.get('/purchases', isUser, function(req, res, next) {
   return purchaseCtrl.getPurchases(req.userId)
-  .then(function(meals) {
-    return res.json(meals);
-  })
-  .catch(function(err) {
-    return res.status(500).json({
-      success: false,
-      message: 'Please try again later',
-      error: err.message
+    .then(function(meals) {
+      return res.json(meals);
+    })
+    .catch(function(err) {
+      return res.status(500).json({
+        success: false,
+        message: 'Please try again later',
+        error: err.message
+      });
     });
-  });
 });
 
 // POST /api/users/purchases
 // Allow user to purchase a meal
 router.post('/purchases', isUser, function(req, res, next) {
   return purchaseCtrl.createPurchase(req.body, req.userId)
-  .then(function(purchase) {
-    mail.sendPurchase(purchase);
-    return res.status(200).json(purchase);
-  })
-  .catch(function(err) {
-    return res.status(500).json({
-      success: false,
-      message: 'Please try again later',
-      error: err.message
+    .then(function(purchase) {
+      mail.sendPurchase(purchase);
+      return res.status(200).json(purchase);
+    })
+    .catch(function(err) {
+      return res.status(500).json({
+        success: false,
+        message: 'Please try again later',
+        error: err.message
+      });
     });
-  });
 });
 
 // GET /api/users/purchases/:id
@@ -421,6 +412,15 @@ router.delete('/requests/:id', isUser, function(req, res) {
         });
       });
   });
+});
+
+// GET /api/users/:id
+// Get a specific user
+router.get('/:id', function(req, res) {
+  return userCtrl.getUser(req.params.id)
+    .then(function(user) {
+      return res.json(user);
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
`/api/users/purchases` was getting matched to `/api/users/:id`. Moved the route `/api/users/:id` to end of file.