### PR TITLE
(fix) Change client-side geocode to server-side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL=postgres://username:password@example.com:5432/dbname
 DATABASE_URL_DEV=postgres://username:password@localhost:5432/dbname
 DATABASE_URL_TEST=postgres://username:password@localhost:5432/dbnametest
+GMAPS_GEOCODE_KEY=ABxzCbA00zLKw0x3xCQr9MOANA1lo2BASdf30
 JWT_SECRET=secret
 MAIL_USER=cooksy@gmailexample.com
 MAIL_CLIENT_ID=456156843521-dsff45654adf5344525684thxdf45d81.apps.googleusercontent.com

--- a/client/src/containers/NearByMeals.js
+++ b/client/src/containers/NearByMeals.js
@@ -201,13 +201,15 @@ class NearByMeals extends Component {
 
   renderInfoContent = (meal) => {
     return (
-      <p>
-        <Link
-          to={`/meals/${meal.id}`}
-          className="NearByMeals-meal-heading"
-        >
-          {meal.name}
-        </Link>
+      <div>
+        <p>
+          <Link
+            to={`/meals/${meal.id}`}
+            className="NearByMeals-meal-heading"
+          >
+            {meal.name}
+          </Link>
+        </p>
 
         <Rating
           value={Math.ceil(meal.rating)}
@@ -217,11 +219,14 @@ class NearByMeals extends Component {
           itemIconStyle={styles.smallIcon}
         />
 
-        <span className="NearByMeals-meal-chef">{meal.chef.username}</span>
-        <p className="NearByMeals-meal-address">
-          {`${meal.address}, ${meal.city}`}
+        <p>
+          <span className="NearByMeals-meal-chef">{meal.chef.username}</span>
+          <br />
+          <span className="NearByMeals-meal-address">
+            {`${meal.address}, ${meal.city}`}
+          </span>
         </p>
-      </p>
+      </div>
     );
   }
 

--- a/client/src/containers/NearByMeals.js
+++ b/client/src/containers/NearByMeals.js
@@ -18,8 +18,8 @@ import './NearByMeals.css';
 // eslint-disable-next-line
 const geocoder = new google.maps.Geocoder();
 
-const defaultIcon = 'http://maps.google.com/mapfiles/ms/icons/red-dot.png';
-const selectedIcon = 'http://maps.google.com/mapfiles/ms/icons/green-dot.png';
+const defaultIcon = 'https://maps.google.com/mapfiles/ms/icons/red-dot.png';
+const selectedIcon = 'https://maps.google.com/mapfiles/ms/icons/green-dot.png';
 
 const styles = {
   smallIcon: {
@@ -52,27 +52,21 @@ class NearByMeals extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let geocodedMeals = [];
-    let markers = [];
-
     if (this.props.meals !== nextProps.meals && _.size(nextProps.meals) !== 0) {
-      _.each(nextProps.meals, meal => {
-        geocodedMeals.push(this.geocodeMeal(meal));
-      });
+      const markers = _.map(nextProps.meals, (meal) => (
+        {
+          id: meal.id,
+          icon: defaultIcon,
+          position: {
+            lat: meal.point.coordinates[0],
+            lng: meal.point.coordinates[1]
+          },
+          showInfo: false,
+          infoContent: this.renderInfoContent(meal)
+        }
+      ));
 
-      Promise.all(geocodedMeals)
-        .then(res => {
-          markers = res.map(meal => (
-            {
-              id: meal.id,
-              icon: defaultIcon,
-              position: meal.location,
-              showInfo: false,
-              infoContent: this.renderInfoContent(meal)
-            }
-          ));
-          this.setState({markers});
-        });
+      this.setState({markers});
     }
   }
 
@@ -84,27 +78,6 @@ class NearByMeals extends Component {
           .scrollIntoView({ block: 'start', behavior: 'smooth' });
       }
     }
-  }
-
-  geocodeMeal = meal => {
-    const address = `${meal.address}, ${meal.city} ${meal.state}, ${meal.zipcode}`;
-
-    return new Promise((resolve, reject) => {
-      geocoder.geocode({address}, (results, status) => {
-        if (status === 'OK') {
-          const geocodedMeal = {
-            ...meal,
-            location: {
-              lat: results[0].geometry.location.lat(),
-              lng: results[0].geometry.location.lng(),
-            }
-          };
-          resolve(geocodedMeal);
-        } else {
-          reject(status);
-        }
-      });
-    });
   }
 
   getCurrentLocation = () => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "heroku-postbuild": "cd client/ && npm install --only=dev && npm install && npm run build"
   },
   "dependencies": {
+    "@google/maps": "^0.4.1",
     "axios": "^0.16.1",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.0",

--- a/src/models/chef.js
+++ b/src/models/chef.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var bcrypt = require('bcryptjs');
+var geocodeAddress = require('../utils/geocode-address');
 
 module.exports = function(sequelize, DataTypes) {
   var Chef = sequelize.define(
@@ -106,25 +107,18 @@ module.exports = function(sequelize, DataTypes) {
       });
   });
 
-  Chef.beforeCreate(function(chef, options) {
-    return sequelize.models.Zipcode.findById(chef.zipcode)
-      .then(function(zip) {
-        chef.point = {
-          type: 'POINT',
-          coordinates: [zip.lat, zip.lng]
-        };
-      });
+  Chef.beforeCreate(function(chef, options, cb) {
+    geocodeAddress(chef, options, cb);
   });
 
-  Chef.beforeUpdate(function(chef, options) {
-    if (chef.zipcode !== chef._previousDataValues.zipcode) {
-      return sequelize.models.Zipcode.findById(chef.zipcode)
-        .then(function(zip) {
-          chef.point = {
-            type: 'POINT',
-            coordinates: [zip.lat, zip.lng]
-          };
-        });
+  Chef.beforeUpdate(function(chef, options, cb) {
+    if (
+      chef.address !== chef._previousDataValues.address ||
+      chef.city !== chef._previousDataValues.city ||
+      chef.state !== chef._previousDataValues.state ||
+      chef.zipcode !== chef._previousDataValues.zipcode
+    ) {
+      geocodeAddress(chef, options, cb);
     }
   });
 

--- a/src/models/meal.js
+++ b/src/models/meal.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var geocodeAddress = require('../utils/geocode-address');
+
 module.exports = function(sequelize, DataTypes) {
   var Meal = sequelize.define('Meal', {
     name: {
@@ -119,25 +121,18 @@ module.exports = function(sequelize, DataTypes) {
     }
   });
 
-  Meal.beforeCreate(function(meal, options) {
-    return sequelize.models.Zipcode.findById(meal.zipcode)
-      .then(function(zip) {
-        meal.point = {
-          type: 'POINT',
-          coordinates: [zip.lat, zip.lng]
-        };
-      });
+  Meal.beforeCreate(function(meal, options, cb) {
+    geocodeAddress(meal, options, cb);
   });
 
-  Meal.beforeUpdate(function(meal, options) {
-    if (meal.zipcode !== meal._previousDataValues.zipcode) {
-      return sequelize.models.Zipcode.findById(meal.zipcode)
-        .then(function(zip) {
-          meal.point = {
-            type: 'POINT',
-            coordinates: [zip.lat, zip.lng]
-          };
-        });
+  Meal.beforeUpdate(function(meal, options, cb) {
+    if (
+      meal.address !== meal._previousDataValues.address ||
+      meal.city !== meal._previousDataValues.city ||
+      meal.state !== meal._previousDataValues.state ||
+      meal.zipcode !== meal._previousDataValues.zipcode
+    ) {
+      geocodeAddress(meal, options, cb);
     }
   });
 

--- a/src/utils/geocode-address.js
+++ b/src/utils/geocode-address.js
@@ -1,0 +1,18 @@
+var googleMapsClient = require('@google/maps').createClient({
+  key: process.env.GMAPS_GEOCODE_KEY
+});
+
+module.exports = function(instance, options, cb) {
+  googleMapsClient.geocode({
+    address: instance.address + ', ' + instance.city + ', ' + instance.state + ' ' + instance.zipcode
+  }, function(err, response) {
+    if (!err) {
+      var latLng = response.json.results[0].geometry.location;
+      instance.point = {
+        type: 'POINT',
+        coordinates: [latLng.lat, latLng.lng]
+      };
+      return cb(null, options);
+    }
+  });
+};


### PR DESCRIPTION
New package on the backend was installed, so remember to run `npm install`.

Also, the `.env` has been updated to now have a `GMAPS_GEOCODE_KEY` which is a Google Maps API key that has the geocoding api enabled. You'll have to grab this key from our frontend or on our Heroku deployment in the config variables section.